### PR TITLE
Add solda order history view with pagination

### DIFF
--- a/apontamento_solda/templates/apontamento_solda/historico.html
+++ b/apontamento_solda/templates/apontamento_solda/historico.html
@@ -1,0 +1,76 @@
+{% extends "base.html" %}
+
+{% block title %}
+<title>Histórico de Ordens de Solda</title>
+{% endblock %}
+
+{% block content %}
+<div class="container mt-4">
+    <h2>Histórico de Ordens de Solda</h2>
+    <div class="table-responsive">
+        <table class="table table-striped">
+            <thead>
+                <tr>
+                    <th>Ordem</th>
+                    <th>Peça</th>
+                    <th>Qt Planejada</th>
+                    <th>Qt Boa</th>
+                    <th>Status</th>
+                    <th>Data</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for peca in page_obj %}
+                <tr>
+                    <td>{{ peca.ordem.ordem }}</td>
+                    <td>{{ peca.peca }}</td>
+                    <td>{{ peca.qtd_planejada }}</td>
+                    <td>{{ peca.qtd_boa }}</td>
+                    <td>{{ peca.ordem.status_atual }}</td>
+                    <td>{{ peca.data|date:"d/m/Y H:i" }}</td>
+                </tr>
+                {% empty %}
+                <tr>
+                    <td colspan="6" class="text-center">Nenhum registro encontrado.</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    <nav aria-label="Page navigation">
+        <ul class="pagination justify-content-center">
+            {% if page_obj.has_previous %}
+            <li class="page-item">
+                <a class="page-link" href="?page={{ page_obj.previous_page_number }}" aria-label="Previous">
+                    <span aria-hidden="true">&laquo;</span>
+                </a>
+            </li>
+            {% else %}
+            <li class="page-item disabled">
+                <span class="page-link" aria-hidden="true">&laquo;</span>
+            </li>
+            {% endif %}
+
+            {% for num in page_obj.paginator.page_range %}
+            {% if page_obj.number == num %}
+            <li class="page-item active"><span class="page-link">{{ num }}</span></li>
+            {% else %}
+            <li class="page-item"><a class="page-link" href="?page={{ num }}">{{ num }}</a></li>
+            {% endif %}
+            {% endfor %}
+
+            {% if page_obj.has_next %}
+            <li class="page-item">
+                <a class="page-link" href="?page={{ page_obj.next_page_number }}" aria-label="Next">
+                    <span aria-hidden="true">&raquo;</span>
+                </a>
+            </li>
+            {% else %}
+            <li class="page-item disabled">
+                <span class="page-link" aria-hidden="true">&raquo;</span>
+            </li>
+            {% endif %}
+        </ul>
+    </nav>
+</div>
+{% endblock %}

--- a/apontamento_solda/urls.py
+++ b/apontamento_solda/urls.py
@@ -26,6 +26,7 @@ urlpatterns = [
 # templates
 urlpatterns += [
     path('', views.planejamento, name='planejamento'),
+    path('historico/', views.historico_ordens, name='historico'),
 ]
 
 # Google sheets

--- a/apontamento_solda/views.py
+++ b/apontamento_solda/views.py
@@ -6,6 +6,7 @@ from django.db import transaction, models, IntegrityError, connection
 from django.shortcuts import get_object_or_404
 from django.db.models.functions import Coalesce
 from django.shortcuts import render
+from django.core.paginator import Paginator
 from django.core.exceptions import ObjectDoesNotExist
 
 import json
@@ -854,6 +855,16 @@ def planejamento(request):
     motivos_maquina_parada = MotivoMaquinaParada.objects.filter(setor__nome='solda').exclude(nome='Finalizada parcial')
 
     return render(request, 'apontamento_solda/planejamento.html', {'motivos_maquina_parada': motivos_maquina_parada})
+
+
+def historico_ordens(request):
+
+    ordens = PecasOrdem.objects.select_related('ordem').order_by('-data')
+    paginator = Paginator(ordens, 10)
+    page_number = request.GET.get('page')
+    page_obj = paginator.get_page(page_number)
+
+    return render(request, 'apontamento_solda/historico.html', {'page_obj': page_obj})
 
 def buscar_maquinas(request):
 


### PR DESCRIPTION
## Summary
- add view to list welding order history with joined ordem details
- expose historico route and template with paginated table

## Testing
- `python manage.py test` *(fails: HTTPSConnectionPool(host='oauth2.googleapis.com', port=443): Max retries exceeded with url: /token (Caused by ProxyError('Unable to connect to proxy', OSError('Tunnel connection failed: 403 Forbidden')))*


------
https://chatgpt.com/codex/tasks/task_e_68c825f3b2e083329c9cf892ecebb42a